### PR TITLE
Added Google's maven repo to buildRepositories

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/data/gradle/rootGradle.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/gradle/rootGradle.kt
@@ -16,6 +16,7 @@ class RootGradleFile(val project: Project) : GradleFile("") {
         buildRepositories.add("mavenLocal()")
         buildRepositories.add("mavenCentral()")
         buildRepositories.add("jcenter()")
+        buildRepositories.add("google()")
         buildRepositories.add("maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }")
     }
 


### PR DESCRIPTION
Google moved version 3 of their build tools and above to their Maven repo, so it needs to be included or Android projects using them won't fully build.