### PR TITLE
Fix Android issues

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/data/gradle/rootGradle.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/gradle/rootGradle.kt
@@ -49,6 +49,7 @@ subprojects {
     mavenLocal()
     mavenCentral()
     jcenter()
+    google()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
   }
 }

--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/android.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/android.kt
@@ -111,7 +111,7 @@ android {
       jniLibs.srcDirs = ['libs']
     }
 
-    instrumentTest.setRoot('tests')
+    androidTest.setRoot('tests')
   }
   packagingOptions {
     // Preventing from license violations (more or less):


### PR DESCRIPTION
Android project can't compile because of two issues:
- missing google() in subproject repos, can't find the linting library
- `instrumentTest` has been depreciated and replaced with `androidTest`