### PR TITLE
Implemented finding default Android SDK location via ANDROID_HOME environment variable.

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/prefs/androidSdkPreference.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/prefs/androidSdkPreference.kt
@@ -8,4 +8,5 @@ import com.github.czyzby.autumn.mvc.stereotype.preference.Property
  */
 @Property("AndroidSdk")
 class AndroidSdkPreference : AbstractStringPreference() {
+    override fun getDefault(): String = System.getenv("ANDROID_HOME").orEmpty()
 }


### PR DESCRIPTION
Implemented finding default Android SDK location via ANDROID_HOME environment variable on first gdx-setup run.